### PR TITLE
Fixes tests, compact and u128 decoding

### DIFF
--- a/src/Codec/Types/Compact.php
+++ b/src/Codec/Types/Compact.php
@@ -51,20 +51,18 @@ class Compact extends ScaleInstance
             return (is_int($data) && $this->compactLength <= 4) ? gmp_strval(Utils::ConvertGMP(intval($data / 4))) : gmp_strval(Utils::ConvertGMP($data));
         }
         $UIntBitLength = 8 * $this->compactLength;
-        foreach (range(4, 67) as $i) {
-            if ($UIntBitLength >= 2 ** ($i - 1) && $UIntBitLength < 2 ** $i) {
-                $UIntBitLength = 2 ** ($i - 1);
-                break;
-            }
-        }
-
         if ($this->compactLength <= 4) {
+            foreach (range(4, 67) as $i) {
+                if ($UIntBitLength >= 2 ** ($i - 1) && $UIntBitLength < 2 ** $i) {
+                    $UIntBitLength = 2 ** ($i - 1);
+                    break;
+                }
+            }
             return gmp_init(intval($this->process("U{$UIntBitLength}", $compactBytes) / 4));
         }
         $parser = new Parser(Utils::bytesToHex($compactBytes->nextBytes($UIntBitLength / 8)));
-        return $parser->readBytes($UIntBitLength / 8)->getGmp();
+        return $parser->readBytes($UIntBitLength / 8, true)->getGmp();
     }
-
 
     /**
      * checkCompactBytes

--- a/src/Codec/Types/U128.php
+++ b/src/Codec/Types/U128.php
@@ -20,7 +20,7 @@ class U128 extends Uint
     public function decode(): GMP
     {
         $parser = new Parser(Utils::bytesToHex($this->nextBytes(16)));
-        return $parser->readBytes(16)->getGmp();
+        return $parser->readBytes(16, true)->getGmp();
     }
 
     public function encode($param)

--- a/src/Codec/Types/U64.php
+++ b/src/Codec/Types/U64.php
@@ -17,8 +17,8 @@ class U64 extends Uint
 {
     public function decode()
     {
-        $u128 = new Uint64(ByteOrder::LE);
-        return $u128->read(new Parser(Utils::bytesToHex($this->nextBytes(8))));
+        $u64 = new Uint64(ByteOrder::LE);
+        return $u64->read(new Parser(Utils::bytesToHex($this->nextBytes(8))));
     }
 
     public function encode($param)

--- a/test/Codec/Test/BaseTest.php
+++ b/test/Codec/Test/BaseTest.php
@@ -32,7 +32,7 @@ final class BaseTest extends TestCase
         $codec = new ScaleInstance($generator);
 
         // inherit
-        $this->assertEquals($codec->process("a", new ScaleBytes($codec->createTypeByTypeString("a")->encode(gmp_init(739571955075788261)))), gmp_init(739571955075788261));
+        $this->assertEquals(0, gmp_cmp($codec->process("a", new ScaleBytes($codec->createTypeByTypeString("a")->encode(gmp_init(739571955075788261)))), gmp_init(739571955075788261)));
         // struct
         $this->assertEquals($codec->process("b", new ScaleBytes($codec->createTypeByTypeString("b")->encode(["b1" => 1, "b2" => [1, 2]]))), ["b1" => 1, "b2" => [1, 2]]);
         // enum

--- a/test/Codec/Test/CompactTest.php
+++ b/test/Codec/Test/CompactTest.php
@@ -18,27 +18,32 @@ final class CompactTest extends TestCase
         $this->assertEquals("04", $codec->createTypeByTypeString("Compact")->encode(gmp_init("1")));
         // u8
         $this->assertEquals("fd03", $codec->createTypeByTypeString("Compact")->encode(2 ** 8 - 1));
-        $this->assertEquals(gmp_sub(gmp_pow("2", 8), 1), $codec->process("Compact", new ScaleBytes("fd03")));
+        $this->assertEquals(0, gmp_cmp(gmp_sub(gmp_pow("2", 8), 1), $codec->process("Compact", new ScaleBytes("fd03"))));
         // u16
         $this->assertEquals("feff0300", $codec->createTypeByTypeString("Compact")->encode(2 ** 16 - 1));
-        $this->assertEquals(gmp_sub(gmp_pow("2", 16), 1), $codec->process("Compact", new ScaleBytes("feff0300")));
+        $this->assertEquals(0, gmp_cmp(gmp_sub(gmp_pow("2", 16), 1), $codec->process("Compact", new ScaleBytes("feff0300"))));
         // u32
         $this->assertEquals("03ffffffff", $codec->createTypeByTypeString("Compact")->encode(gmp_sub(gmp_pow("2", 32), 1)));
         $this->assertEquals("4294967295", $codec->process("Compact<u32>", new ScaleBytes("03ffffffff")));
         // u64
         $this->assertEquals("13ffffffffffffffff", $codec->createTypeByTypeString("Compact")->encode(gmp_sub(gmp_pow("2", 64), 1)));
-        $this->assertEquals(gmp_sub(gmp_pow("2", 64), 1), $codec->process("Compact", new ScaleBytes("13ffffffffffffffff")));
+        $this->assertEquals(0, gmp_cmp(gmp_sub(gmp_pow("2", 64), 1), $codec->process("Compact", new ScaleBytes("13ffffffffffffffff"))));
         // u128
         $this->assertEquals("33ffffffffffffffffffffffffffffffff", $codec->createTypeByTypeString("Compact")->encode(gmp_sub(gmp_pow("2", 128), 1)));
-        $this->assertEquals(gmp_sub(gmp_pow("2", 128), 1), $codec->process("Compact", new ScaleBytes("33ffffffffffffffffffffffffffffffff")));
+        $this->assertEquals(0, gmp_cmp(gmp_sub(gmp_pow("2", 128), 1), $codec->process("Compact", new ScaleBytes("33ffffffffffffffffffffffffffffffff"))));
         // u256
         $this->assertEquals("73ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", $codec->createTypeByTypeString("Compact")->encode(gmp_sub(gmp_pow("2", 256), 1)));
-        $this->assertEquals(gmp_sub(gmp_pow("2", 256), 1), $codec->process("Compact", new ScaleBytes("73ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")));
-        // u512
+        $this->assertEquals(0, gmp_cmp(gmp_sub(gmp_pow("2", 256), 1), $codec->process("Compact", new ScaleBytes("73ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"))));
+        // >u512
         $this->assertEquals("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
             $codec->createTypeByTypeString("Compact")->encode(gmp_sub(gmp_pow("2", 536), 1)));
-        $this->assertEquals(gmp_sub(gmp_pow("2", 536), 1), $codec->process("Compact", new ScaleBytes("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")));
-
+        $decoded = $codec->process("Compact", new ScaleBytes("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+        $this->assertEquals(0, gmp_cmp(gmp_sub(gmp_pow("2", 536), 1), $decoded));
+        // >u512 - test LE order
+        $this->assertEquals("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3f",
+            $codec->createTypeByTypeString("Compact")->encode(gmp_sub(gmp_pow("2", 534), 1)));
+        $decoded = $codec->process("Compact", new ScaleBytes("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3f"));
+        $this->assertEquals(0, gmp_cmp(gmp_sub(gmp_pow("2", 534), 1), $decoded));
 
         // check out of range > 2**536-1
         $this->expectException(\OutOfRangeException::class);

--- a/test/Codec/Test/EventTest.php
+++ b/test/Codec/Test/EventTest.php
@@ -28,11 +28,12 @@ final class EventTest extends TestCase
         $decodeEvent = $codec->process("Vec<EventRecord>",
             new ScaleBytes("0x1400000000000000a0dc040b00000000020000000100000005028897e4fdc4b935d9afd1440e2705559c46508024357e255c584efde50c5b625507c12e8b63d2592412cbbde38e96181551234bb57ec8438c1281e212b5bed72bbce3e7a5d0010000000000000000000000000100000013060b817c070000000000000000000000000000010000000504e693f8c8c6043a5d8c8ed64d56523d157625011947a8a79881987d9e9100963a4320df01000000000000000000000000000001000000000080e8780a00000000000000"), $metadataInstant["metadata"]);
 
+        $this->assertEquals(0, gmp_cmp($decodeEvent[1]['params'][2]['value'], $balance = gmp_init(1995648263100)));
         $this->assertEquals(["phase" => 0, "extrinsic_index" => 1, "look_up" => "0502", "module_id" => "Balances",
             "event_id" => "Transfer", "params" => [
                 ["type" => "AccountId", "value" => "8897e4fdc4b935d9afd1440e2705559c46508024357e255c584efde50c5b6255"],
                 ["type" => "AccountId", "value" => "07c12e8b63d2592412cbbde38e96181551234bb57ec8438c1281e212b5bed72b"],
-                ["type" => "Balance", "value" => gmp_init(1995648263100)],
+                ["type" => "Balance", "value" => $balance],
             ], "topic" => [],
         ], $decodeEvent[1]);
     }

--- a/test/Codec/Test/TypeTest.php
+++ b/test/Codec/Test/TypeTest.php
@@ -123,8 +123,10 @@ final class TypeTest extends TestCase
         $codec = $codec->createTypeByTypeString("Struct");
         $codec->typeStruct = ["a" => "Compact", "b" => "Compact"];
         $codec->init(new ScaleBytes("0c00"));
-        $this->assertEquals(["a" => gmp_init(3), "b" => gmp_init(0)], $codec->decode());
 
+        $r = $codec->decode();
+        $this->assertEquals(0, gmp_cmp($r['a'], gmp_init(3)));
+        $this->assertEquals(0, gmp_cmp($r['b'], gmp_init(0)));
         $this->assertEquals("0c00", $codec->encode(["a" => 3, "b" => 0]));
     }
 

--- a/test/Codec/Test/UintTest.php
+++ b/test/Codec/Test/UintTest.php
@@ -32,7 +32,6 @@ final class UintTest extends TestCase
     public function testU32int ()
     {
         $codec = new ScaleInstance(Base::create());
-
         $this->assertEquals(100, $codec->process("U32", new ScaleBytes("64000000")));
         $this->assertEquals("64000000", $codec->createTypeByTypeString("U32")->encode(100));
         $this->expectException(\InvalidArgumentException::class);
@@ -42,7 +41,6 @@ final class UintTest extends TestCase
     public function testU64int ()
     {
         $codec = new ScaleInstance(Base::create());
-
         $this->assertEquals(184467440737095, $codec->process("U64", new ScaleBytes("471b47acc5a70000")));
         $this->assertEquals("471b47acc5a70000", $codec->createTypeByTypeString("U64")->encode(184467440737095));
         $this->expectException(\InvalidArgumentException::class);
@@ -53,7 +51,7 @@ final class UintTest extends TestCase
     public function testU128 ()
     {
         $codec = new ScaleInstance(Base::create());
-        $this->assertEquals(gmp_init("739571955075788261"), $codec->process("U128", new ScaleBytes("e52d2254c67c430a0000000000000000")));
+        $this->assertEquals(0, gmp_cmp(gmp_init("739571955075788261"), $codec->process("U128", new ScaleBytes("e52d2254c67c430a0000000000000000"))));
         $codec = $codec->createTypeByTypeString("U128");
         $this->assertEquals("e52d2254c67c430a0000000000000000", $codec->encode(739571955075788261));
 


### PR DESCRIPTION
Hi @gmajor-encrypt,

I found an issue regarding decoding of u128 values, it was not considering LE order.
And also for compact numbers that were higher than 512. The limit by the algorithm was 512 instead of 2^536-1
Finally I fixed a few tests as phpUnit when comparing gmp values only check the type (gmp) and not the value itself. That's why those were not catched before.